### PR TITLE
gettext for maven build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,11 @@
         <configuration>
           <source>1.5</source>
           <target>1.5</target>
+          <excludes>
+            <exclude>**/dbus/bin/*</exclude>
+            <exclude>**/dbus/test/*</exclude>
+            <exclude>**/dbus/viewer/*</exclude>
+          </excludes>
         </configuration>
       </plugin>
       <plugin>
@@ -44,6 +49,26 @@
           <environmentVariables>
             <LD_LIBRARY_PATH>${settings.localRepository}/cx/ath/matthew/libmatthew-libunix/0.5</LD_LIBRARY_PATH>
           </environmentVariables>
+        </configuration>
+      </plugin>
+
+      <plugin>
+        <groupId>com.googlecode.gettext-commons</groupId>
+        <artifactId>gettext-maven-plugin</artifactId>
+        <version>1.2.4</version>
+        <executions>
+          <execution>
+            <id>convert-po-class</id>
+            <phase>compile</phase>
+            <goals>
+              <goal>dist</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <poDirectory>${basedir}/translations</poDirectory>
+          <targetBundle>dbusjava_localized</targetBundle>
+          <outputFormat>class</outputFormat>
         </configuration>
       </plugin>
     </plugins>

--- a/src/main/java/org/freedesktop/dbus/Gettext.java
+++ b/src/main/java/org/freedesktop/dbus/Gettext.java
@@ -18,6 +18,7 @@
  */
 package org.freedesktop.dbus;
 
+import java.util.Locale;
 import java.util.ResourceBundle;
 
 public class Gettext
@@ -25,7 +26,7 @@ public class Gettext
    private static ResourceBundle myResources = null;
    static {
       try {
-         myResources = ResourceBundle.getBundle("dbusjava_localized");
+         myResources = ResourceBundle.getBundle("dbusjava_localized", Locale.UK);
       }
       catch (java.util.MissingResourceException e) {
          e.printStackTrace();


### PR DESCRIPTION
hi, I need to use this library in maven project and your repo seems to be the most active, so I needed to do some fixes:
- I've added maven plugin to generate property files from maven build
- also, I've excluded bin, tests, and viewer packages from generated library as I presume these classes should be in separate artifacts.

it would be nice if you could merge this stuff so I could redirect people to use code from this repo to build my project.
